### PR TITLE
Factorize tolgee export in a single API call

### DIFF
--- a/src/Resources/config/translation_providers.php
+++ b/src/Resources/config/translation_providers.php
@@ -5,17 +5,24 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Netlogix\SymfonyTolgeeTranslationProvider\TolgeeProviderFactory;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 
 // @codeCoverageIgnoreStart
 return static function (ContainerConfigurator $container) {
-    $container->services()
+    $services = $container->services();
+
+    $services
+        ->set('translation.loader.array', ArrayLoader::class)
+        ->tag('translation.loader', ['alias' => 'array']);
+
+    $services
         ->set('translation.provider_factory.tolgee', TolgeeProviderFactory::class)
         ->autowire(true)
         ->args([
-            service('http_client'),
-            service('logger'),
-            param('kernel.default_locale'),
-            service('translation.loader.json')
+            '$client' => service('http_client'),
+            '$logger' => service('logger'),
+            '$defaultLocale' => param('kernel.default_locale'),
+            '$loader' => service('translation.loader.array'),
         ])
         ->tag('translation.provider_factory');
 };

--- a/src/TolgeeProvider.php
+++ b/src/TolgeeProvider.php
@@ -13,6 +13,7 @@ use Symfony\Component\Intl\Locales;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\Multipart\FormDataPart;
 use Symfony\Component\Translation\Loader\JsonFileLoader;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Provider\ProviderInterface;
 use Symfony\Component\Translation\TranslatorBag;
 use Symfony\Component\Translation\TranslatorBagInterface;
@@ -63,39 +64,39 @@ class TolgeeProvider implements ProviderInterface
 
     public function read(array $domains, array $locales): TranslatorBag
     {
-        $locales = $locales ?: $this->getLanguages();
-        $domains = $domains ?: $this->getAllNamespaces();
         $translatorBag = new TranslatorBag();
+        $locales = $locales ?: array_values(iterator_to_array($this->getLanguages()));
+        $domains = $domains ?: $this->getAllNamespaces();
 
-        $query = [
-            'format' => 'JSON',
-            'zip' => false
-        ];
+        $files = $this->exportFiles($domains, $locales);
 
-        if ($this->filterState) {
-            $query['filterState'] = $this->filterState;
-        }
+        foreach ($domains as $domain) {
+            if ($domain === null) {
+                $this->logger->warning(sprintf(
+                   'Unnamed domains are not allowed',
+                   $locale
+                ));
+                continue;
+            }
 
-        foreach ($locales as $locale) {
-            foreach ($domains as $domain) {
-                if ($domain === null) {
-                    $this->logger->warning(sprintf(
-                        'Unnamed domains are not allowed',
-                        $locale
-                    ));
+            foreach ($locales as $language) {
+                $expected = sprintf('%s/%s.json', $domain, $language);
+                if (!isset($files[$expected])) {
                     continue;
                 }
-                $this->exportFileCallback(
-                    function (?string $jsonFile) use ($translatorBag, $locale, $domain) {
-                        if ($jsonFile) {
-                            $tolgeeCatalogue = $this->loader->load($jsonFile, $locale, $domain);
-                            $translatorBag->addCatalogue($tolgeeCatalogue);
-                        }
-                    },
-                    $domain,
-                    $locale,
-                    $this->filterState
-                );
+                $content = $files[$expected];
+                $decoded = json_decode($content, true);
+                if ($decoded === null) {
+                    $this->logger->warning(sprintf('Unable to decode JSON from %s: %s', $expected, json_last_error_msg()));
+                    continue;
+                }
+                try {
+                    $arrayLoader = new ArrayLoader();
+                    $tolgeeCatalogue = $arrayLoader->load($decoded, $language, $domain);
+                    $translatorBag->addCatalogue($tolgeeCatalogue);
+                } catch (\Exception $e) {
+                    $this->logger->warning(sprintf('Unable to load translations from %s: %s', $expected, $e->getMessage()));
+                }
             }
         }
 
@@ -406,54 +407,81 @@ class TolgeeProvider implements ProviderInterface
         } while ($pages > $currentPage);
     }
 
-
-    private function exportFileCallback(
-        callable $callback,
-        string $domain,
-        string $locale,
-        ?string $filterState = null
-    ): void {
-
+    private function exportFiles(array $domains, array $locales): array
+    {
         $query = [
-            'filterNamespace' => $domain,
-            'languages' => $locale,
             'format' => 'JSON',
-            'zip' => false
+            'zip' => true,
+            'languages' => is_array($locales) ? implode(',', $locales) : $locales,
+            'filterNamespace' => is_array($domains) ? implode(',', $domains) : $domains,
         ];
 
-        if ($filterState) {
-            $query['filterState'] = $filterState;
+        if ($this->filterState) {
+            $query['filterState'] = $this->filterState;
         }
 
         $response = $this->client->request('GET', 'export', [
             'buffer' => true,
-            'query' => $query
+            'query' => $query,
         ]);
 
         if (400 === $response->getStatusCode()) {
-
             $data = $response->toArray(false);
             if ($data['code'] ?? '' === 'no_exported_result') {
-                $callback(null);
-                return;
+                return [];
             }
         }
 
         $this->checkResponseStatusCode($response);
 
-        $jsonFile = tempnam(sys_get_temp_dir(), "tolgee.$domain.$locale.json");
-        $jsonFileHandler = fopen($jsonFile, 'w');
+        return $this->extractZipContents($response);
+    }
 
-        foreach ($this->client->stream($response) as $chunk) {
-            fwrite($jsonFileHandler, $chunk->getContent());
+    private function extractZipContents(ResponseInterface $response): array
+    {
+        $zipFile = tempnam(sys_get_temp_dir(), 'tolgee_export');
+        if ($zipFile === false) {
+            throw new TolgeeException('Unable to create temporary file for export', 1700650000, $response);
         }
 
-        fclose($jsonFileHandler);
+        $zipFileHandle = fopen($zipFile, 'w');
+        if ($zipFileHandle === false) {
+            throw new TolgeeException('Unable to open temporary file for export', 1700650001, $response);
+        }
 
-        $callback($jsonFile);
+        foreach ($this->client->stream($response) as $chunk) {
+            fwrite($zipFileHandle, $chunk->getContent());
+        }
 
-        unlink($jsonFile);
+        fclose($zipFileHandle);
+
+        $zip = new \ZipArchive();
+        $res = $zip->open($zipFile);
+        if ($res !== true) {
+            unlink($zipFile);
+            throw new TolgeeException('Unable to open export ZIP archive', 1700650002, $response);
+        }
+
+        $map = [];
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $name = $zip->getNameIndex($i);
+            if ($name === false) {
+                continue;
+            }
+            $content = $zip->getFromIndex($i);
+            if ($content === false) {
+                continue;
+            }
+            $map[$name] = $content;
+        }
+
+        $zip->close();
+        unlink($zipFile);
+
+        return $map;
     }
+
+
 
     private function getAllNamespaces(): array
     {

--- a/src/TolgeeProvider.php
+++ b/src/TolgeeProvider.php
@@ -483,13 +483,8 @@ class TolgeeProvider implements ProviderInterface
             $map[$name] = $content;
         }
 
-        try {
-            $zip->close();
-        } catch(\Exception $e) {
-            ;
-        } finally {
-            unlink($zipFile);
-        }
+        $zip->close();
+        unlink($zipFile);
 
         return $map;
     }

--- a/src/TolgeeProvider.php
+++ b/src/TolgeeProvider.php
@@ -12,7 +12,6 @@ use Symfony\Component\HttpClient\Exception\ServerException;
 use Symfony\Component\Intl\Locales;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\Multipart\FormDataPart;
-use Symfony\Component\Translation\Loader\JsonFileLoader;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Provider\ProviderInterface;
 use Symfony\Component\Translation\TranslatorBag;
@@ -43,7 +42,7 @@ class TolgeeProvider implements ProviderInterface
 
     public function __construct(
         HttpClientInterface $client,
-        JsonFileLoader      $loader,
+        ArrayLoader         $loader,
         LoggerInterface     $logger,
         string              $defaultLocale,
         string              $endpoint,
@@ -66,16 +65,13 @@ class TolgeeProvider implements ProviderInterface
     {
         $translatorBag = new TranslatorBag();
         $locales = $locales ?: array_values(iterator_to_array($this->getLanguages()));
-        $domains = $domains ?: $this->getAllNamespaces();
+        $domains = $domains ?: array_values($this->getAllNamespaces());
 
         $files = $this->exportFiles($domains, $locales);
 
         foreach ($domains as $domain) {
             if ($domain === null) {
-                $this->logger->warning(sprintf(
-                   'Unnamed domains are not allowed',
-                   $locale
-                ));
+                $this->logger->warning('Unnamed domains are not allowed');
                 continue;
             }
 
@@ -84,15 +80,13 @@ class TolgeeProvider implements ProviderInterface
                 if (!isset($files[$expected])) {
                     continue;
                 }
-                $content = $files[$expected];
-                $decoded = json_decode($content, true);
+                $decoded = json_decode($files[$expected], true);
                 if ($decoded === null) {
                     $this->logger->warning(sprintf('Unable to decode JSON from %s: %s', $expected, json_last_error_msg()));
                     continue;
                 }
                 try {
-                    $arrayLoader = new ArrayLoader();
-                    $tolgeeCatalogue = $arrayLoader->load($decoded, $language, $domain);
+                    $tolgeeCatalogue = $this->loader->load($decoded, $language, $domain);
                     $translatorBag->addCatalogue($tolgeeCatalogue);
                 } catch (\Exception $e) {
                     $this->logger->warning(sprintf('Unable to load translations from %s: %s', $expected, $e->getMessage()));
@@ -409,11 +403,20 @@ class TolgeeProvider implements ProviderInterface
 
     private function exportFiles(array $domains, array $locales): array
     {
+        if (empty($domains) || empty($locales)) {
+            $this->logger->warning('Export skipped because domains or locales are empty', [
+                'domains' => $domains,
+                'locales' => $locales,
+            ]);
+
+            return [];
+        }
+
         $query = [
             'format' => 'JSON',
             'zip' => true,
-            'languages' => is_array($locales) ? implode(',', $locales) : $locales,
-            'filterNamespace' => is_array($domains) ? implode(',', $domains) : $domains,
+            'languages' => implode(',', $locales),
+            'filterNamespace' => implode(',', $domains),
         ];
 
         if ($this->filterState) {
@@ -428,6 +431,11 @@ class TolgeeProvider implements ProviderInterface
         if (400 === $response->getStatusCode()) {
             $data = $response->toArray(false);
             if ($data['code'] ?? '' === 'no_exported_result') {
+                $this->logger->warning('No exported result from export API', [
+                    'domains' => $domains,
+                    'locales' => $locales,
+                    'filterState' => $this->filterState,
+                ]);
                 return [];
             }
         }
@@ -475,8 +483,13 @@ class TolgeeProvider implements ProviderInterface
             $map[$name] = $content;
         }
 
-        $zip->close();
-        unlink($zipFile);
+        try {
+            $zip->close();
+        } catch(\Exception $e) {
+            ;
+        } finally {
+            unlink($zipFile);
+        }
 
         return $map;
     }

--- a/src/TolgeeProviderFactory.php
+++ b/src/TolgeeProviderFactory.php
@@ -7,7 +7,7 @@ namespace Netlogix\SymfonyTolgeeTranslationProvider;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Translation\Exception\IncompleteDsnException;
 use Symfony\Component\Translation\Exception\UnsupportedSchemeException;
-use Symfony\Component\Translation\Loader\JsonFileLoader;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Provider\AbstractProviderFactory;
 use Symfony\Component\Translation\Provider\Dsn;
 use Symfony\Component\Translation\Provider\ProviderInterface;
@@ -15,7 +15,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class TolgeeProviderFactory extends AbstractProviderFactory
 {
-    /** @var JsonFileLoader */
+    /** @var ArrayLoader */
     private $loader;
 
     /** @var HttpClientInterface */
@@ -32,7 +32,7 @@ final class TolgeeProviderFactory extends AbstractProviderFactory
         HttpClientInterface $client,
         LoggerInterface     $logger,
         string              $defaultLocale,
-        JsonFileLoader      $loader
+        ArrayLoader         $loader
     ) {
         $this->client = $client;
         $this->logger = $logger;

--- a/tests/Fixtures/HttpClientFixture.php
+++ b/tests/Fixtures/HttpClientFixture.php
@@ -31,4 +31,42 @@ class HttpClientFixture
             $page
         ));
     }
+
+    public static function getExportZip(string $fixture, string $namespace, string $languages): string
+    {
+        $zip = new \ZipArchive();
+        $tmpZip = tempnam(sys_get_temp_dir(), 'tolgee_zip_') . ".zip";
+        $res = $zip->open($tmpZip, \ZipArchive::CREATE);
+        if ($res !== true) {
+            throw new \RuntimeException('Unable to open ZIP file for writing at ' . $tmpZip . ': error ' . $res);
+        }
+
+        $namespaces = explode(',', $namespace);
+        $langArray = explode(',', $languages);
+
+        // For each namespace and language combination, try to add the fixture file
+        foreach ($namespaces as $ns) {
+            foreach ($langArray as $lang) {
+                $filename = sprintf('%s/%s.json', $ns, $lang);
+                $jsonPath = sprintf(
+                    '%s/export.%s.%s.get.json',
+                    self::getPath($fixture),
+                    $ns,
+                    $lang
+                );
+                if (file_exists($jsonPath)) {
+                    $content = file_get_contents($jsonPath);
+                    if (!$zip->addFromString($filename, $content)) {
+                        $zip->close();
+                        unlink($tmpZip);
+                        throw new \RuntimeException('Failed to add file to ZIP: ' . $filename);
+                    }
+                }
+            }
+        }
+        $zip->close();
+        $content = file_get_contents($tmpZip);
+        unlink($tmpZip);
+        return $content;
+    }
 }

--- a/tests/Functional/TolgeeProviderTest.php
+++ b/tests/Functional/TolgeeProviderTest.php
@@ -44,6 +44,7 @@ class TolgeeProviderTest extends KernelTestCase
 
     public function testReadTranslations(): void
     {
+
         $this->client->setResponseFactory(function ($method, $url, $options) {
             $fixture = 'TolgeeApi/Functional/Read';
             if ($method == 'GET' && strpos($url, '/used-namespaces') > 1) {
@@ -59,6 +60,9 @@ class TolgeeProviderTest extends KernelTestCase
                 $filterNamespace = $query['filterNamespace'];
                 $languages = $query['languages'];
                 $data = HttpClientFixture::getExportZip($fixture, $filterNamespace, $languages);
+            }
+            else {
+                throw new \RuntimeException(sprintf('Unhandled request: %s %s', $method, $url));
             }
 
             return new MockResponse($data ?? '');
@@ -94,7 +98,7 @@ class TolgeeProviderTest extends KernelTestCase
             )
         );
 
-        $this->assertSame($translations, $excpect);
+        $this->assertSame($excpect, $translations);
     }
 
     public function testWrite(): void

--- a/tests/Functional/TolgeeProviderTest.php
+++ b/tests/Functional/TolgeeProviderTest.php
@@ -58,11 +58,7 @@ class TolgeeProviderTest extends KernelTestCase
                 $query = $options['query'];
                 $filterNamespace = $query['filterNamespace'];
                 $languages = $query['languages'];
-                $data = HttpClientFixture::getData(
-                    $fixture,
-                    join('.', ['export', $filterNamespace, $languages]),
-                    $method
-                );
+                $data = HttpClientFixture::getExportZip($fixture, $filterNamespace, $languages);
             }
 
             return new MockResponse($data ?? '');

--- a/tests/Symfony/TolgeeProviderFactoryTest.php
+++ b/tests/Symfony/TolgeeProviderFactoryTest.php
@@ -7,19 +7,13 @@ namespace Netlogix\SymfonyTolgeeTranslationProvider\Test\Symfony;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Netlogix\SymfonyTolgeeTranslationProvider\TolgeeProviderFactory as ProviderFactory;
-use Symfony\Component\Translation\Dumper\JsonFileDumper;
-use Symfony\Component\Translation\Loader\JsonFileLoader;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Provider\Dsn;
 use Symfony\Component\Translation\Provider\ProviderFactoryInterface;
 use Symfony\Component\Translation\Test\ProviderFactoryTestCase;
 
 class TolgeeProviderFactoryTest extends ProviderFactoryTestCase
 {
-    /**
-     * @var JsonFileDumper
-     */
-    protected $jsonFileDumper;
-
     public static function supportsProvider(): iterable
     {
         yield "http" => [true, 'tolgee://1:API_KEY@tolgee.dev'];
@@ -73,7 +67,7 @@ class TolgeeProviderFactoryTest extends ProviderFactoryTestCase
         $response = new MockResponse($zipContent);
         $httpClient = new MockHttpClient([$response]);
         $loader = $this->getLoader();
-        $factory = new ProviderFactory($httpClient, $this->getLogger(),  $this->getDefaultLocale(), $loader, $this->getJsonFileDumper());
+        $factory = new ProviderFactory($httpClient, $this->getLogger(),  $this->getDefaultLocale(), $loader);
         $provider = $factory->create(new Dsn('tolgees://2:API_KEY@tolgee.dev:8080'));
 
         // Make a real HTTP request.
@@ -88,16 +82,11 @@ class TolgeeProviderFactoryTest extends ProviderFactoryTestCase
 
     public function createFactory(): ProviderFactoryInterface
     {
-        return new ProviderFactory($this->getClient(), $this->getLogger(), $this->getDefaultLocale(), $this->getLoader(), $this->getJsonFileDumper());
+        return new ProviderFactory($this->getClient(), $this->getLogger(), $this->getDefaultLocale(), $this->getLoader());
     }
 
-    protected function getLoader(): JsonFileLoader
+    protected function getLoader(): ArrayLoader
     {
-        return $this->loader ?? $this->loader = $this->createMock(JsonFileLoader::class);
-    }
-
-    protected function getJsonFileDumper(): JsonFileDumper
-    {
-        return $this->jsonFileDumper ?? $this->jsonFileDumper = $this->createMock(JsonFileDumper::class);
+        return $this->loader ?? $this->loader = new ArrayLoader();
     }
 }

--- a/tests/Symfony/TolgeeProviderFactoryTest.php
+++ b/tests/Symfony/TolgeeProviderFactoryTest.php
@@ -62,17 +62,28 @@ class TolgeeProviderFactoryTest extends ProviderFactoryTestCase
 
     public function testBaseUri()
     {
-        $response = new MockResponse(json_encode(['foo' => 'bar']));
+        $zip = new \ZipArchive();
+        $tmpZip = tempnam(sys_get_temp_dir(), 'test_export_') . ".zip";
+        $zip->open($tmpZip, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        $zip->addFromString('messages/en.json', json_encode(['foo' => 'bar']));
+        $zip->close();
+        $zipContent = file_get_contents($tmpZip);
+        unlink($tmpZip);
+
+        $response = new MockResponse($zipContent);
         $httpClient = new MockHttpClient([$response]);
         $loader = $this->getLoader();
-        $loader->expects($this->once())->method('load')->willReturn(new \Symfony\Component\Translation\MessageCatalogue('en', ['foo' => 'bar']));
         $factory = new ProviderFactory($httpClient, $this->getLogger(),  $this->getDefaultLocale(), $loader, $this->getJsonFileDumper());
         $provider = $factory->create(new Dsn('tolgees://2:API_KEY@tolgee.dev:8080'));
 
         // Make a real HTTP request.
         $provider->read(['messages'], ['en']);
 
-        $this->assertEquals('https://tolgee.dev:8080/v2/projects/2/export?filterNamespace=messages&languages=en&format=JSON&zip=0', $response->getRequestUrl());
+        $this->assertStringContainsString('export', $response->getRequestUrl());
+        $this->assertStringContainsString('filterNamespace=messages', $response->getRequestUrl());
+        $this->assertStringContainsString('languages=en', $response->getRequestUrl());
+        $this->assertStringContainsString('format=JSON', $response->getRequestUrl());
+        $this->assertStringContainsString('zip=1', $response->getRequestUrl());
     }
 
     public function createFactory(): ProviderFactoryInterface

--- a/tests/Symfony/TolgeeProviderTest.php
+++ b/tests/Symfony/TolgeeProviderTest.php
@@ -13,27 +13,24 @@ use Symfony\Component\Translation\Provider\ProviderInterface;
 use Symfony\Component\Translation\Test\ProviderTestCase;
 use Symfony\Component\Translation\TranslatorBag;
 use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Netlogix\SymfonyTolgeeTranslationProvider\TolgeeProvider;
-use Symfony\Component\Translation\Loader\JsonFileLoader;
 
 class TolgeeProviderTest extends ProviderTestCase
 {
-    /**
-     * @return LoaderInterface|MockObject
-     */
     protected function getLoader(): LoaderInterface
     {
-        return $this->loader ?? $this->loader = $this->createMock(JsonFileLoader::class);
+        return $this->loader ?? $this->loader = new ArrayLoader();
     }
 
-    public static function createProvider($client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint): ProviderInterface
+    public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint): ProviderInterface
     {
         return new TolgeeProvider($client, $loader, $logger, $defaultLocale, $endpoint);
     }
 
     public static  function toStringProvider(): iterable
     {
-        $loader = new JsonFileLoader();
+        $loader = new ArrayLoader();
         yield 'app.tolgee.io' => [
             self::createProvider(
                 self::getHttpClient(),

--- a/tests/Symfony/TolgeeProviderTest.php
+++ b/tests/Symfony/TolgeeProviderTest.php
@@ -96,25 +96,26 @@ class TolgeeProviderTest extends ProviderTestCase
     {
         $response = function (string $method, string $url, array $options = []) use ($locale, $domain, $responseContent): ResponseInterface {
             $this->assertSame('GET', $method);
-            $this->assertSame('https://app.tolgee.io/v2/projects/1337/export?filterNamespace=' . $domain . '&languages=' . $locale . '&format=JSON&zip=0', $url);
 
-            return new MockResponse(json_encode($responseContent));
+            // Check URL contains all required parameters (order may vary)
+            $this->assertStringContainsString('filterNamespace=' . $domain, $url);
+            $this->assertStringContainsString('languages=' . $locale, $url);
+            $this->assertStringContainsString('format=JSON', $url);
+            $this->assertStringContainsString('zip=1', $url);
+
+            $zip = new \ZipArchive();
+            $tmpZip = tempnam(sys_get_temp_dir(), 'test_export_') . ".zip";
+            $zip->open($tmpZip, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+            $zip->addFromString(sprintf('%s/%s.json', $domain, $locale), json_encode($responseContent));
+            $zip->close();
+            $content = file_get_contents($tmpZip);
+            unlink($tmpZip);
+            return new MockResponse($content);
         };
 
-        $jsonFile = tempnam(sys_get_temp_dir(), "tolgee.$domain.$locale.json");
-        file_put_contents($jsonFile, json_encode($responseContent));
-
-        $loader = $this->getLoader();
-        $loader->expects($this->once())
-            ->method('load')
-            ->willReturn((new JsonFileLoader())->load($jsonFile, $locale, $domain));
-
-        $client = self::getHttpClient();
-
-        $provider = self::createProvider($client, $loader, $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
+        $client = self::getHttpClient($response);
+        $provider = self::createProvider($client, $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'app.tolgee.io');
         $translatorBag = $provider->read([$domain], [$locale]);
-        unset($jsonFile);
-
         $this->assertEquals($expectedTranslatorBag->getCatalogue($locale)->all($domain), $translatorBag->getCatalogue($locale)->all($domain));
     }
 
@@ -180,38 +181,35 @@ class TolgeeProviderTest extends ProviderTestCase
     public function testReadForManyLocalesAndManyDomains(array $locales, array $domains, array $responseContents, TranslatorBag $expectedTranslatorBag)
     {
         $response = function (string $method, string $url, array $options = []) use ($locales, $domains, $responseContents): ResponseInterface {
-
             $this->assertSame('GET', $method);
-
             $query = [];
             parse_str(parse_url($url, PHP_URL_QUERY), $query);
             self::assertArrayHasKey('filterNamespace', $query);
             self::assertArrayHasKey('languages', $query);
             $domain = $query['filterNamespace'];
             $locale = $query['languages'];
-            self::assertContains($domain, $domains);
-            self::assertContains($locale, $locales);
-
-            $this->assertSame('https://app.tolgee.io/v2/projects/1337/export?filterNamespace=' . $domain . '&languages=' . $locale . '&format=JSON&zip=0', $url);
-
-            return new MockResponse(json_encode($responseContents[$domain][$locale]));
+            self::assertEquals($domain, join(",", $domains));
+            self::assertEquals($locale, join(",", $locales));
+            $zip = new \ZipArchive();
+            $tmpZip = tempnam(sys_get_temp_dir(), 'test_export_') . ".zip";
+            $zip->open($tmpZip, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+            foreach ($domains as $domain) {
+                foreach ($locales as $locale) {
+                   $zip->addFromString(sprintf('%s/%s.json', $domain, $locale), json_encode($responseContents[$domain][$locale]));
+               }
+            }
+            $zip->close();
+            $content = file_get_contents($tmpZip);
+            unlink($tmpZip);
+            return new MockResponse($content);
         };
 
-        $loader = $this->getLoader();
-        $loader->expects($this->atLeastOnce())
-            ->method('load')
-            ->willReturnCallback(function ($resource, $locale, $domain) use ($responseContents) {
-                self::assertEquals(json_encode($responseContents[$domain][$locale]), file_get_contents($resource));
-                return (new ArrayLoader())->load($responseContents[$domain][$locale], $locale, $domain);
-            });
         $client = self::getHttpClient($response);
-        $provider = self::createProvider($client, $loader, $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
-
+        $provider = self::createProvider($client, $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'app.tolgee.io');
         $translatorBag = $provider->read($domains, $locales);
-
         foreach ($domains as $domain) {
             foreach ($locales as $locale) {
-                $this->assertEquals($expectedTranslatorBag->getCatalogue($locale)->all($domain), $translatorBag->getCatalogue($locale)->all($domain));
+              $this->assertEquals($expectedTranslatorBag->getCatalogue($locale)->all($domain), $translatorBag->getCatalogue($locale)->all($domain));
             }
         }
     }

--- a/tests/Unit/TolgeeProviderFactoryTest.php
+++ b/tests/Unit/TolgeeProviderFactoryTest.php
@@ -11,7 +11,7 @@ use Netlogix\SymfonyTolgeeTranslationProvider\TolgeeProviderFactory;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Translation\Exception\IncompleteDsnException;
 use Symfony\Component\Translation\Exception\UnsupportedSchemeException;
-use Symfony\Component\Translation\Loader\JsonFileLoader;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Provider\ProviderInterface;
 use Symfony\Component\Translation\Provider\Dsn;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -99,7 +99,7 @@ class TolgeeProviderFactoryTest extends TestCase
             $client,
             $this->createMock(LoggerInterface::class),
             'en',
-            new JsonFileLoader()
+            new ArrayLoader()
         );
     }
 }

--- a/tests/Unit/TolgeeProviderPrivateTest.php
+++ b/tests/Unit/TolgeeProviderPrivateTest.php
@@ -12,7 +12,7 @@ use Netlogix\SymfonyTolgeeTranslationProvider\TolgeeProvider;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Mime\Part\DataPart;
-use Symfony\Component\Translation\Loader\JsonFileLoader;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Provider\ProviderInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -34,7 +34,7 @@ class TolgeeProviderPrivateTest extends TestCase
     {
         return new TolgeeProvider(
             $client ?? new MockHttpClient(),
-            $this->createMock(JsonFileLoader::class),
+            $this->createMock(ArrayLoader::class),
             $this->createMock(LoggerInterface::class),
             'en',
             ''


### PR DESCRIPTION
Due to recent usage spikes on their cloud infrastructure, the Tolgee team introduced rate-limits on their `/export` API. Ref. [Tolgee Discord](https://discord.com/channels/887646957043064872/900306899822587924/1458069357203820554).

During the `translation:pull` command, the provider is making a call for each `<domain> x <locale>` tuple. This leads to the rate limit being quickly reached and prevents the build of the application.

This PR reduces the required number of API calls to a single request to `/export` endpoint. 
- It switches to the `zip` output of the API (which is required when fetching more than one locale or more than 1 namespace)
- unzip the response file in memory
- then feed the translator with individual `<domain>/<locale>` json files